### PR TITLE
Fix no_proxy support if proxy info pulled from https_proxy

### DIFF
--- a/methods/https.cc
+++ b/methods/https.cc
@@ -187,13 +187,13 @@ void HttpsMethod::SetupProxy()						/*{{{*/
    if (UseProxy == "DIRECT")
       return;
 
-   if (UseProxy.empty() == false) 
+   // Parse no_proxy, a comma (,) separated list of domains we don't want to use    
+   // a proxy for so we stop right here if it is in the list
+   if (getenv("no_proxy") != 0 && CheckDomainList(ServerName.Host,getenv("no_proxy")) == true)
+      return;
+
+   if (UseProxy.empty() == true)
    {
-      // Parse no_proxy, a comma (,) separated list of domains we don't want to use
-      // a proxy for so we stop right here if it is in the list
-      if (getenv("no_proxy") != 0 && CheckDomainList(ServerName.Host,getenv("no_proxy")) == true)
-	 return;
-   } else {
       const char* result = getenv("https_proxy");
       // FIXME: Fall back to http_proxy is to remain compatible with
       // existing setups and behaviour of apt.conf.  This should be


### PR DESCRIPTION
When using the https transport mechanism, `$no_proxy` is ignored if apt is getting it's proxy information from `$https_proxy` (as opposed to `Acquire::https::Proxy`` somewhere in apt config). If the source of proxy information is Acquire::https::Proxy set in apt.conf (or apt.conf.d), then $no_proxy is honored. 

This patch performs the same `$no_proxy` check that happens when `Acquire::https::Proxy` is used.