### PR TITLE
doc: update path to periodic options script

### DIFF
--- a/doc/apt.conf.5.xml
+++ b/doc/apt.conf.5.xml
@@ -988,7 +988,7 @@ DPkg::TriggersPending "true";</literallayout></para>
    <title>Periodic and Archives options</title>
    <para><literal>APT::Periodic</literal> and <literal>APT::Archives</literal>
    groups of options configure behavior of apt periodic updates, which is
-   done by the <literal>/etc/cron.daily/apt</literal> script. See the top of
+   done by the <literal>/usr/lib/apt/apt.systemd.daily</literal> script. See the top of
    this script for the brief documentation of these options.
    </para>
  </refsect1>


### PR DESCRIPTION
The man page for `apt.conf` refers users to the top of the `/etc/cron.daily/apt` script for Periodic and Archive option documentation, but commit 14669d4b95f0f6a9b215d7fa5aebbc3b7198585d moved this script to `/usr/lib/apt/apt.systemd.daily`