### PR TITLE
https: allow socks proxies

### DIFF
--- a/methods/https.cc
+++ b/methods/https.cc
@@ -216,6 +216,24 @@ void HttpsMethod::SetupProxy()						/*{{{*/
          curl_easy_setopt(curl, CURLOPT_PROXYUSERNAME, Proxy.User.c_str());
          curl_easy_setopt(curl, CURLOPT_PROXYPASSWORD, Proxy.Password.c_str());
       }
+#if LIBCURL_VERSION_NUM >= 0x071800
+      if (Proxy.Access == "socks")
+      {
+         curl_easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS4);
+      }
+      else if (Proxy.Access == "socks4a")
+      {
+         curl_easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS4A);
+      }
+      else if (Proxy.Access == "socks5")
+      {
+         curl_easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5);
+      }
+      else if (Proxy.Access == "socks5h")
+      {
+         curl_easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5_HOSTNAME);
+      }
+#endif
    }
 }									/*}}}*/
 // HttpsMethod::Fetch - Fetch an item					/*{{{*/


### PR DESCRIPTION
This allows the usage of socks proxies for the https method.
Especially the socks5h is useful when using ssh to create a socks proxy and also resolving hostnames over the proxy.
E.g. add to /etc/apt.conf:
Acquire::https::Proxy "socks5h://localhost:1080";

It would be really useful to have this for the normal http method as well, but it seems this would be hard to implement since that doesn't use libcurl.
Ideally it would "simply" use the same code as https method in case you have a socks proxy defined for the requested http url.