### PR TITLE
Modified link to doc/style.txt in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can also use the Ninja generator of cmake, to do that pass
 to the cmake invocation, and then use ninja instead of make.
 
 The source code uses in most parts a relatively uncommon indent convention,
-namely 3 spaces with 8 space tab (see [doc/style.txt](http://anonscm.debian.org/gitweb/?p=apt/apt.git;a=blob;f=doc/style.txt) for more on this).
+namely 3 spaces with 8 space tab (see [doc/style.txt](https://anonscm.debian.org/cgit/apt/apt.git/tree/doc/style.txt) for more on this).
 Adhering to it avoids unnecessary code-churn destroying history (aka: `git blame`)
 and you are therefore encouraged to write patches in this style.
 Your editor can surely help you with this, for vim the settings would be


### PR DESCRIPTION
Updated  [doc/style.txt] (https://anonscm.debian.org/gitweb/?p=apt/apt.git%3ba=blob%3bf=doc/style.txt)  to [doc/style.txt](https://anonscm.debian.org/cgit/apt/apt.git/tree/doc/style.txt) in README.md