### PR TITLE
_filedir takes an extension, not a glob

### DIFF
--- a/completions/bash/apt
+++ b/completions/bash/apt
@@ -189,7 +189,7 @@ _apt()
             install)
                 COMPREPLY=( $( apt-cache --no-generate pkgnames "$cur" \
                     2> /dev/null ) )
-                _filedir "*.deb"
+                _filedir "deb"
                 return 0
                 ;;
             source|build-dep|showsrc|policy)


### PR DESCRIPTION
This fixes #28.