### PR TITLE
Only call _filedir if we're completing something that apt will know to install.

### DIFF
--- a/completions/bash/apt
+++ b/completions/bash/apt
@@ -189,7 +189,9 @@ _apt()
             install)
                 COMPREPLY=( $( apt-cache --no-generate pkgnames "$cur" \
                     2> /dev/null ) )
-                _filedir "*.deb"
+                if [[ "$cur" == ./* || "$cur" == /* ]]; then
+                    _filedir "deb"
+                fi
                 return 0
                 ;;
             source|build-dep|showsrc|policy)


### PR DESCRIPTION
Resolves #28.