### PR TITLE
Doc: `--allow-unauthenticated` mentioned in `--force-yes`

### DIFF
--- a/doc/apt-get.8.xml
+++ b/doc/apt-get.8.xml
@@ -457,7 +457,11 @@
      without prompting if it is doing something potentially harmful. It 
      should not be used except in very special situations. Using 
      <literal>force-yes</literal> can potentially destroy your system! 
-     Configuration Item: <literal>APT::Get::force-yes</literal>. This is deprecated and replaced by <option>--allow-downgrades</option>, <option>--allow-remove-essential</option>, <option>--allow-change-held-packages</option> in 1.1. </para></listitem>
+     Configuration Item: <literal>APT::Get::force-yes</literal>. This is deprecated and replaced by 
+     <option>--allow-unauthenticated</option>
+     , <option>--allow-downgrades</option>
+     , <option>--allow-remove-essential</option>
+     , <option>--allow-change-held-packages</option> in 1.1. </para></listitem>
      </varlistentry>
 
      <varlistentry><term><option>--print-uris</option></term>


### PR DESCRIPTION
`--force-yes` also [allows unauthenticated downloads](https://github.com/Debian/apt/blob/master/apt-private/private-download.cc#L81).

I strongly suggest to explicitly mention this setting, even it was 
[introduced >= 4 years ago](https://github.com/Debian/apt/commit/866893a619e00966ae6b1549c4bfce92d6c17db1#diff-edbfff1fb5ec5ef12241a4e048b2ac39), i.e. before the `--force-yes` deprecation in version 1.1.