### PR TITLE
cmdline/apt.cc: fix whitespace to match coding style

### DIFF
--- a/cmdline/apt.cc
+++ b/cmdline/apt.cc
@@ -79,11 +79,11 @@ static std::vector<aptDispatchWithHelp> GetCommands()			/*{{{*/
 
       // for compat with muscle memory
       {"dist-upgrade", &DoDistUpgrade, nullptr},
-      {"showsrc",&ShowSrcPackage, nullptr},
-      {"depends",&Depends, nullptr},
-      {"rdepends",&RDepends, nullptr},
-      {"policy",&Policy, nullptr},
-      {"build-dep", &DoBuildDep,nullptr},
+      {"showsrc", &ShowSrcPackage, nullptr},
+      {"depends", &Depends, nullptr},
+      {"rdepends", &RDepends, nullptr},
+      {"policy", &Policy, nullptr},
+      {"build-dep", &DoBuildDep, nullptr},
       {"clean", &DoClean, nullptr},
       {"autoclean", &DoAutoClean, nullptr},
       {"auto-clean", &DoAutoClean, nullptr},


### PR DESCRIPTION
I just found some tiny coding style issues in the file cmdline/apt.cc while I was reading it to find out the difference between `dist-upgrade` and `full-upgrade` :smile:.

By the way, great job on the apt CLI interface. It is really a pleasure to use!

Cheers, Alex