### PR TITLE
apt.cc: Add "apt info" alias for muscle memory

### DIFF
--- a/cmdline/apt.cc
+++ b/cmdline/apt.cc
@@ -90,6 +90,7 @@ static std::vector<aptDispatchWithHelp> GetCommands()			/*{{{*/
       {"source", &DoSource, nullptr},
       {"download", &DoDownload, nullptr},
       {"changelog", &DoChangelog, nullptr},
+      {"info", &ShowPackage, nullptr},
 
       {nullptr, nullptr, nullptr}
    };


### PR DESCRIPTION
Muscle memory is acquired from querying package info with tools like snap, dnf etc.

Ideally there is a chance to make the output of human readable `info` compatible across tools.