### PR TITLE
Remove `register` keyword

### DIFF
--- a/apt-pkg/contrib/md5.cc
+++ b/apt-pkg/contrib/md5.cc
@@ -80,7 +80,7 @@ static void byteSwap(uint32_t *buf, unsigned words)
 
 static void MD5Transform(uint32_t buf[4], uint32_t const in[16])
 {
-   register uint32_t a, b, c, d;
+   uint32_t a, b, c, d;
    
    a = buf[0];
    b = buf[1];


### PR DESCRIPTION
In C++17 `register` keyword was removed. Current gcc 8.1.0 produces
following warning if `-std=c++17` flag is used:

warning: ISO C++17 does not allow 'register' storage class specifier
[-Wregister]

GCC almost completely ignores `register` keyword, with rare exception of
`-O0` when additional copy from/to stack may be generated.

For simplicity of the codebase it is better to just remove this
problematic keyword where it is not strictly required.

See: http://en.cppreference.com/w/cpp/language/storage_duration

Upstream-Status: Pending

Signed-off-by: Khem Raj <raj.khem@gmail.com>