### PR TITLE
Fixed typo in German man page.

### DIFF
--- a/doc/po/de.po
+++ b/doc/po/de.po
@@ -670,7 +670,7 @@ msgid ""
 msgstr ""
 "Ganz wie <command>apt</command> selbst ist seine Handbuchseite als "
 "Endanwenderschnittstelle gedacht und erwähnt als solche nur die am "
-"häufigsten benutzten Befehle sowie Optionen. Die geschieht zum Teil, um "
+"häufigsten benutzten Befehle sowie Optionen. Dies geschieht zum Teil, um "
 "keine Informationen an mehreren Stellen zu duplizieren und zum Teil, um "
 "Leser nicht mit einem Überfluss an Optionen und Einzelheiten zu überwältigen."
 


### PR DESCRIPTION
The word "dies" (this) is missing a letter.