### PR TITLE
Do not include squashfs file systems in df output.

### DIFF
--- a/apt-pkg/deb/dpkgpm.cc
+++ b/apt-pkg/deb/dpkgpm.cc
@@ -2460,7 +2460,7 @@ void pkgDPkgPM::WriteApportReport(const char *pkgpath, const char *errormsg)
    {
 
       fprintf(report, "Df:\n");
-      FILE *log = popen("/bin/df -l","r");
+      FILE *log = popen("/bin/df -l -x squashfs","r");
       if(log != NULL)
       {
 	 char buf[1024];


### PR DESCRIPTION
This will fix Launchpad bug 1756595.