### PR TITLE
Remove redundant "interface" from warning

### DIFF
--- a/apt-private/private-main.cc
+++ b/apt-private/private-main.cc
@@ -80,7 +80,7 @@ void CheckIfCalledByScript(int argc, const char *argv[])		/*{{{*/
    {
       std::cerr << std::endl
                 << "WARNING: " << flNotDir(argv[0]) << " "
-                << "does not have a stable CLI interface. "
+                << "does not have a stable CLI. "
                 << "Use with caution in scripts."
                 << std::endl
                 << std::endl;


### PR DESCRIPTION
This is about as minor as they get, but remove "interface" after "CLI" in the apt script warning