### PR TITLE
Add apt-get update launch hook

### DIFF
--- a/apt-private/private-update.cc
+++ b/apt-private/private-update.cc
@@ -35,6 +35,8 @@ bool DoUpdate(CommandLine &CmdL)
 
    CacheFile Cache;
 
+   RunScripts("APT::Update::On-Launch");
+
    // Get the source list
    if (Cache.BuildSourceList() == false)
       return false;

--- a/doc/examples/configure-index
+++ b/doc/examples/configure-index
@@ -156,6 +156,7 @@ APT
 
   Update
   {
+     On-Launch {"touch /var/lib/apt/on-launch-update-stamp"; };
      Pre-Invoke {"touch /var/lib/apt/pre-update-stamp"; };
      Post-Invoke {"touch /var/lib/apt/post-update-stamp"; };
   };

--- a/test/integration/test-apt-update-hooks
+++ b/test/integration/test-apt-update-hooks
@@ -16,6 +16,7 @@ APTARCHIVE="$(readlink -f ./aptarchive)"
 
 signreleasefiles 'Joe Sixpack'
 
+echo 'APT::Update::On-Launch { "echo ON_LAUNCH"; };' >> rootdir/etc/apt/apt.conf.d/display-success.conf
 echo 'APT::Update::Post-Invoke-Success { "echo SUCCESS"; };' >> rootdir/etc/apt/apt.conf.d/display-success.conf
 echo 'APT::Update::Post-Invoke { "echo RUN"; };' >> rootdir/etc/apt/apt.conf.d/display-success.conf
 
@@ -23,6 +24,7 @@ echo 'APT::Update::Post-Invoke { "echo RUN"; };' >> rootdir/etc/apt/apt.conf.d/d
 msgmsg "All sources OK => run Post-Invoke-Success and Post-Invoke"
 testsuccess aptget update
 cp rootdir/tmp/testsuccess.output aptupdate.output
+testsuccess grep "ON_LAUNCH" aptupdate.output
 testsuccess grep "RUN" aptupdate.output
 testsuccess grep "SUCCESS" aptupdate.output
 
@@ -35,6 +37,7 @@ testfailure apt update
 cp rootdir/tmp/testfailure.output aptupdate.output
 listcurrentlistsdirectory > lists.after
 testfailure cmp lists.before lists.after
+testsuccess grep "ON_LAUNCH" aptupdate.output
 testsuccess grep "RUN" aptupdate.output
 testsuccess grep "SUCCESS" aptupdate.output
 
@@ -45,5 +48,6 @@ mv lists.after lists.before
 testfailure apt update
 cp rootdir/tmp/testfailure.output aptupdate.output
 testfileequal lists.before "$(listcurrentlistsdirectory)"
+testsuccess grep "ON_LAUNCH" aptupdate.output
 testsuccess grep "RUN" aptupdate.output
 testfailure grep "SUCCESS" aptupdate.output


### PR DESCRIPTION
This hook can be used to update the used sources lists.
Use-case: A script can be used to generate the apt sources list which
will then be used by apt-get update.