### PR TITLE
Fix redundant acronym

### DIFF
--- a/apt-private/private-main.cc
+++ b/apt-private/private-main.cc
@@ -81,7 +81,7 @@ void CheckIfCalledByScript(int argc, const char *argv[])		/*{{{*/
    {
       std::cerr << std::endl
                 << "WARNING: " << flNotDir(argv[0]) << " "
-                << "does not have a stable CLI interface. "
+                << "does not have a stable command line interface. "
                 << "Use with caution in scripts."
                 << std::endl
                 << std::endl;

--- a/apt-private/private-main.cc
+++ b/apt-private/private-main.cc
@@ -81,7 +81,7 @@ void CheckIfCalledByScript(int argc, const char *argv[])		/*{{{*/
    {
       std::cerr << std::endl
                 << "WARNING: " << flNotDir(argv[0]) << " "
-                << "does not have a stable command line interface. "
+                << "does not have a stable CLI. "
                 << "Use with caution in scripts."
                 << std::endl
                 << std::endl;


### PR DESCRIPTION
Currently says "does not have a stable CLI interface," which means "does not have a stable command line interface interface," which is redundant.
I also changed the text from what is was in my previous PR to make it shorter and easier to read.
https://en.wikipedia.org/wiki/RAS_syndrome