### PR TITLE
include array in apt-pkg/contrib/configuration.cc

### DIFF
--- a/apt-pkg/contrib/configuration.cc
+++ b/apt-pkg/contrib/configuration.cc
@@ -31,6 +31,7 @@
 #include <string.h>
 
 #include <algorithm>
+#include <array>
 #include <fstream>
 #include <iterator>
 #include <numeric>


### PR DESCRIPTION
clang fails otherwise, due to c4da2ff42da55ffc38c77a9170dc151216d75962