### PR TITLE
srvrec: Keep support for older resolver

### DIFF
--- a/apt-pkg/contrib/srvrec.cc
+++ b/apt-pkg/contrib/srvrec.cc
@@ -62,6 +62,7 @@ bool GetSrvRecords(std::string name, std::vector<SrvRec> &Result)
    unsigned char answer[PACKETSZ];
    int answer_len, compressed_name_len;
    int answer_count;
+#if __RES >= 19991006
    struct __res_state res;
 
    if (res_ninit(&res) != 0)
@@ -71,6 +72,12 @@ bool GetSrvRecords(std::string name, std::vector<SrvRec> &Result)
    std::shared_ptr<void> guard(&res, res_nclose);
 
    answer_len = res_nquery(&res, name.c_str(), C_IN, T_SRV, answer, sizeof(answer));
+#else
+   if (res_init() != 0)
+      return _error->Errno("res_init", "Failed to init resolver");
+
+   answer_len = res_query(name.c_str(), C_IN, T_SRV, answer, sizeof(answer));
+#endif //__RES >= 19991006
    if (answer_len == -1)
       return false;
    if (answer_len < (int)sizeof(HEADER))


### PR DESCRIPTION
Some C libraries e.g. musl do not implement the new res_n* APIs
therefore keep the old implementation as fallback and check __RES
version macro to determine the API level

Signed-off-by: Khem Raj <raj.khem@gmail.com>
Cc: Julian Andres Klode <julian.klode@canonical.com>