### PR TITLE
gpgv: improve error reporting for signed-by repositories

### DIFF
--- a/methods/gpgv.cc
+++ b/methods/gpgv.cc
@@ -473,7 +473,30 @@ bool GPGVMethod::URIAcquire(std::string const &Message, FetchItem *Itm)
          }
          if (!Signers.NoPubKey.empty())
          {
+            if (keyFpts || keyFiles) {
+               string keys;
+               first = true;
+               for (auto const &I : keyFpts) {
+                  if (first) {
+                     first = false;
+                  } else {
+                     keys.append(", ");
+                  }
+                  keys.append(I);
+               }
+               for (auto const &I : keyFiles) {
+                  if (first) {
+                     first = false;
+                  } else {
+                     keys.append(_(", "));
+                  }
+                  keys.append(I);
+               }
+             errmsg += _("The following signatures couldn't be verified because the public key is not in the configured set (");
+             errmsg.append(keys).append(_("):\n"));
+            } else {
              errmsg += _("The following signatures couldn't be verified because the public key is not available:\n");
+            }
             for (auto const &I : Signers.NoPubKey)
                errmsg.append(I).append("\n");
          }


### PR DESCRIPTION
This happens periodically when a pinned repository's keys expire, as in: https://github.com/kubernetes/release/issues/1982#issuecomment-838902947

This is a rough mock-up imagining better error reporting.

In the normal case, one just has to find all the missing keys and add them to `/etc/apt/trusted.gpg.d`, but in the pinned case, that doesn't actually work, and the error message as of 2.0.5 (Ubuntu 20.04.2 LTS) is confusing.

I'm not wed to any of the output, messaging, formatting, or style.