### PR TITLE
aptwebserver.cc: Include <array>

### DIFF
--- a/test/interactive-helper/aptwebserver.cc
+++ b/test/interactive-helper/aptwebserver.cc
@@ -22,6 +22,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
 #include <fstream>
 #include <iostream>
 #include <list>


### PR DESCRIPTION
This helps getting std::array definition

Fixes
test/interactive-helper/aptwebserver.cc:36:55: error: constexpr variable cannot have non-literal type 'const std::array<std::array<const char *, 2>, 6>'
   constexpr std::array<std::array<char const *,2>,6> htmlencode = {{

Upstream-Status: Pending
Signed-off-by: Khem Raj <raj.khem@gmail.com>