### PR TITLE
Do not assert overly-permissive perms on history.log, use umask default allow operator override

### DIFF
--- a/apt-pkg/deb/dpkgpm.cc
+++ b/apt-pkg/deb/dpkgpm.cc
@@ -1039,7 +1039,6 @@ bool pkgDPkgPM::OpenLog()
       if (d->history_out == NULL)
 	 return _error->WarningE("OpenLog", _("Could not open file '%s'"), history_name.c_str());
       SetCloseExec(fileno(d->history_out), true);
-      chmod(history_name.c_str(), 0644);
       fprintf(d->history_out, "\nStart-Date: %s\n", timestr);
       string remove, purge, install, reinstall, upgrade, downgrade;
       for (pkgCache::PkgIterator I = Cache.PkgBegin(); I.end() == false; ++I)


### PR DESCRIPTION
This addresses the topic found in [Question 696930](https://answers.launchpad.net/ubuntu/+source/apt/+question/696930) and [DISA STIG V-238337](https://www.stigviewer.com/stig/canonical_ubuntu_20.04_lts/2022-09-07/finding/V-238337). 

Very simple, 1-line removal to stop apt from asserting 0644 permissions on history.log where unnecessary, overriding operator intent. 

This might be one for you, @julian-klode! 

